### PR TITLE
Clarify "Replace" in I-D submission form

### DIFF
--- a/ietf/submit/forms.py
+++ b/ietf/submit/forms.py
@@ -502,7 +502,7 @@ class SubmitterForm(NameEmailForm):
         return name
 
 class ReplacesForm(forms.Form):
-    replaces = SearchableDocumentsField(required=False, help_text="Any Internet-Drafts that this document replaces (approval required for replacing an Internet-Draft you are not the author of)")
+    replaces = SearchableDocumentsField(required=False, help_text="An I-D submission will be automatically attached to the previous version of the I-D with the same name, or assigned "-00" version if no previous version exists. If this submission is intended to replace an I-D with a different name (e.g. when an individual I-D is adopted as a Working Group document), please enter that name here. (Approval required to replace an I-D for which you are not an author.)")
 
     def __init__(self, *args, **kwargs):
         self.name = kwargs.pop("name")


### PR DESCRIPTION
Update help text In the "Replacement Information" section of the "Status" tab